### PR TITLE
Optimized grf reading

### DIFF
--- a/GRF.Tests/GRFTests.cs
+++ b/GRF.Tests/GRFTests.cs
@@ -64,11 +64,10 @@ namespace GRF.Tests
                 "data\\t2_¹è°æ1-1.bmp" };
             grf.Load( inputFile );
 
-            var entries = grf.Entries;
-
             foreach( var path in expectedPaths )
             {
-                Assert.AreEqual( path, entries[path].Path );
+                int index = grf.EntryNames.IndexOf(path);
+                Assert.AreEqual( path, grf.Entries[index].Path );
             }
         }
 
@@ -89,11 +88,10 @@ namespace GRF.Tests
                 ("data\\t2_¹è°æ1-1.bmp", "t2_¹è°æ1-1.bmp") };
             grf.Load( inputFile );
 
-            var entries = grf.Entries;
-
             foreach( var (path, name) in expectedPathAndName )
             {
-                Assert.AreEqual( name, entries[path].Name );
+                int index = grf.EntryNames.IndexOf(path);
+                Assert.AreEqual(name, grf.Entries[index].Name);
             }
         }
 
@@ -114,11 +112,10 @@ namespace GRF.Tests
                 ("data\\t2_¹è°æ1-1.bmp", "bmp") };
             grf.Load( inputFile );
 
-            var entries = grf.Entries;
-
             foreach( var (path, type) in expectedPathAndTypes )
             {
-                Assert.AreEqual( type, entries[path].Type );
+                int index = grf.EntryNames.IndexOf(path);
+                Assert.AreEqual(type, grf.Entries[index].Type);
             }
         }
 
@@ -132,10 +129,7 @@ namespace GRF.Tests
             var entries = grf.Entries;
 
             Assert.IsNotEmpty( entries );
-            foreach( var entry in entries.Values )
-            {
-                Assert.AreEqual( entry.UncompressedSize, entry.GetUncompressedData().Length );
-            }
+            entries.ForEach(entry => Assert.AreEqual(entry.header.uncompressedSize, entry.GetUncompressedData().Length));
         }
 
         [Test]
@@ -148,11 +142,7 @@ namespace GRF.Tests
             var entries = grf.Entries;
 
             Assert.IsNotEmpty( entries );
-            foreach( var entry in entries.Values )
-            {
-                Assert.AreEqual( entry.UncompressedSize, entry.GetUncompressedData().Length );
-                Assert.AreEqual( entry.UncompressedSize, entry.GetUncompressedData().Length );
-            }
+            entries.ForEach(entry => Assert.AreEqual(entry.header.uncompressedSize, entry.GetUncompressedData().Length));
         }
 
         [Test]

--- a/GRF/GrfCollection.cs
+++ b/GRF/GrfCollection.cs
@@ -37,13 +37,18 @@ namespace GRF
 
         public bool FindEntry( string entryPath, out GrfEntry file )
         {
-            foreach( var grf in _loadedGrfs )
-            {
-                if( grf.Entries.TryGetValue( entryPath, out file ) )
-                    return true;
-            }
+            GrfEntry _file = null;
+            int hashCode = entryPath.GetHashCode();
+
             file = null;
-            return false;
+            foreach(Grf grf in _loadedGrfs) {
+                _file = grf.Entries.FirstOrDefault(entry => entry.GetHashCode().Equals(hashCode));
+                if (file != null)
+                    break;
+            }
+            file = _file;
+
+            return (file != null);
         }
 
         public List<string> AllFileNames()

--- a/GRF/GrfEntryHeader.cs
+++ b/GRF/GrfEntryHeader.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace GRF
+{
+    public class GrfEntryHeader
+    {
+        public uint fileOffset { get; internal set; }
+        public uint compressedSize { get; internal set; }
+        public uint compressedSizeAligned { get; internal set; }
+        public uint uncompressedSize { get; internal set; }
+        public FileFlag flags { get; internal set; }
+    }
+}

--- a/GRF/GrfFileHeader.cs
+++ b/GRF/GrfFileHeader.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace GRF
+{
+    public class GrfFileHeader
+    {
+        public byte[] signature { get; internal set; }
+        public byte[] encryptKey { get; internal set; }
+        public uint fileOffset { get; internal set; }
+        public uint seed { get; internal set; }
+        public uint fileCount { get; internal set; }
+        public GrfFormat version { get; internal set; }
+    }
+}

--- a/GRF/GrfFormat.cs
+++ b/GRF/GrfFormat.cs
@@ -1,6 +1,6 @@
 ﻿namespace GRF
 {
-    public enum GrfFormat
+    public enum GrfFormat : uint
     {
         Version102 = 0x102,
         Version103 = 0x103,


### PR DESCRIPTION
This optimizes reading larges GRF files.
Before all files are cached in memory (the uncompressed body), as @arminherling says, in 32 bits systems may have trouble with it.

The entries now are basically been cached only the headers. Basically is a GRF table list without the compressed content as before.

The content only will read when `GrfEntry.GetUncompressedData()`, only caches after the first call.

Issue related #1 